### PR TITLE
feat: make deps compatible with d9

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,12 @@ This will render as:
 
 Install Storybook as usual:
 
-```
+```console
+# Make use of modern versions of yarn.
+yarn set version berry
+# Avoid pnp.
+echo 'nodeLinker: node-modules' >> .yarnrc.yml
+# Install and configure stock Storybook.
 yarn dlx sb init --builder webpack5 --type server
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         "php": ">=8.1",
         "ext-dom": "*",
         "ext-mbstring": "*",
-        "symfony/dom-crawler": "^6",
-        "twig/twig": "^3"
+        "symfony/dom-crawler": "^4.4.45 || ^6",
+        "twig/twig": "^2.15.4 || ^3"
     },
     "require-dev": {
         "enlightn/security-checker": "^1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eca6d5fc85bea74bd7707807bb719cba",
+    "content-hash": "e9fe5db2eae6ab49f26700fad8b09c15",
     "packages": [
         {
             "name": "masterminds/html5",


### PR DESCRIPTION
Installing `drupal/storybook` in D9 is not possible due to some dependencies here.