### PR TITLE
$_selected_story can be NULL

### DIFF
--- a/src/Twig/Node/StoryNode.php
+++ b/src/Twig/Node/StoryNode.php
@@ -87,7 +87,7 @@ final class StoryNode extends Node implements NodeOutputInterface
 
         $compiler
             ->addDebugInfo($this)
-            ->write('if ($_selected_story === FALSE) {')
+            ->write('if ($_selected_story === FALSE || $_selected_story === NULL) {')
             ->indent();
 
         $this->putMetadataIntoVariable($compiler, '_story_meta')


### PR DESCRIPTION
We are using the following tools:
* Drupal 10.1.8
* storybook module 1.0.0-alpha4
* Twig 3.6.1
* twig-storybook 1.3.0

And `$_selected_story` is NULL, not FALSE so the stories are not collected.