### PR TITLE
Support Twig 4.x with YieldReady

### DIFF
--- a/src/Twig/Node/StoriesNode.php
+++ b/src/Twig/Node/StoriesNode.php
@@ -6,11 +6,13 @@ use Twig\Compiler;
 use Twig\Node\Expression\AbstractExpression;
 use Twig\Node\Node;
 use TwigStorybook\Twig\TwigExtension;
+use Twig\Attribute\YieldReady;
 
 /**
  * The StoriesNode class extends the Twig Node class, providing functionality
  * specific to story nodes in Twig templates.
  */
+#[YieldReady]
 final class StoriesNode extends Node
 {
     use NodeTrait; // Use the functionality defined in NodeTrait.

--- a/src/Twig/Node/StoryNode.php
+++ b/src/Twig/Node/StoryNode.php
@@ -7,6 +7,7 @@ use Twig\Compiler;
 use Twig\Node\Expression\AbstractExpression;
 use Twig\Node\Node;
 use Twig\Node\NodeOutputInterface;
+use Twig\Attribute\YieldReady;
 
 /**
  * StoryNode Class
@@ -14,6 +15,7 @@ use Twig\Node\NodeOutputInterface;
  * This class extends the `Node` class from the Twig library and implements the `NodeOutputInterface`.
  * It represents a single "story" node in the template tree.
  */
+#[YieldReady]
 final class StoryNode extends Node implements NodeOutputInterface
 {
     use NodeTrait;


### PR DESCRIPTION
chore: [#3560490](https://www.drupal.org/project/storybook/issues/3560490) Dependent package does not support Twig 4.x yield in Drupal 11.3

```
Twig\Error\SyntaxError: An exception has been thrown during the compilation of a template ("You cannot enable the "use_yield" option of Twig as node "TwigStorybook\Twig\Node\StoriesNode" is not marked as ready for it; please make it ready and then flag it with the #[\Twig\Attribute\YieldReady] attribute.")
```